### PR TITLE
redis_loader: support loading GFFs via URL

### DIFF
--- a/redis_loader/redis_loader/__main__.py
+++ b/redis_loader/redis_loader/__main__.py
@@ -3,7 +3,6 @@
 # Python
 import argparse
 import os
-import pathlib
 from collections import defaultdict
 # module
 import redis_loader
@@ -278,7 +277,6 @@ def parseArgs():
     required=True,
     action=EnvAction,
     envvar=gffgene_envvar,
-    type=pathlib.Path,
     default=argparse.SUPPRESS,  # removes "(default: None)" from help text
     help=('The GFF file containing gene records (can also be specified using '
          f'the {gffgene_envvar} environment variable).'))
@@ -289,7 +287,6 @@ def parseArgs():
     required=True,
     action=EnvAction,
     envvar=gffchr_envvar,
-    type=pathlib.Path,
     default=argparse.SUPPRESS,  # removes "(default: None)" from help text
     help=('The GFF file containing chromosome/supercontig records (can also be '
          f'specified using the {gffchr_envvar} environment variable).'))
@@ -299,7 +296,6 @@ def parseArgs():
     required=True,
     action=EnvAction,
     envvar=gfa_envvar,
-    type=pathlib.Path,
     default=argparse.SUPPRESS,  # removes "(default: None)" from help text
     help=('The GFA file containing gene-gene family associations (can also be '
          f'specified using the {gfa_envvar} environment variable).'))

--- a/redis_loader/redis_loader/__main__.py
+++ b/redis_loader/redis_loader/__main__.py
@@ -278,7 +278,7 @@ def parseArgs():
     action=EnvAction,
     envvar=gffgene_envvar,
     default=argparse.SUPPRESS,  # removes "(default: None)" from help text
-    help=('The GFF file containing gene records (can also be specified using '
+    help=('The GFF(.gz) file containing gene records (can also be specified using '
          f'the {gffgene_envvar} environment variable).'))
   gffchr_envvar = 'CHROMOSOME_GFF_FILE'
   gff_parser.add_argument(
@@ -288,7 +288,7 @@ def parseArgs():
     action=EnvAction,
     envvar=gffchr_envvar,
     default=argparse.SUPPRESS,  # removes "(default: None)" from help text
-    help=('The GFF file containing chromosome/supercontig records (can also be '
+    help=('The GFF(.gz) file containing chromosome/supercontig records (can also be '
          f'specified using the {gffchr_envvar} environment variable).'))
   gfa_envvar = 'GFA_FILE'
   gff_parser.add_argument(
@@ -297,7 +297,7 @@ def parseArgs():
     action=EnvAction,
     envvar=gfa_envvar,
     default=argparse.SUPPRESS,  # removes "(default: None)" from help text
-    help=('The GFA file containing gene-gene family associations (can also be '
+    help=('The GFA(.gz) file containing gene-gene family associations (can also be '
          f'specified using the {gfa_envvar} environment variable).'))
 
   return parser.parse_args()

--- a/redis_loader/redis_loader/__main__.py
+++ b/redis_loader/redis_loader/__main__.py
@@ -278,8 +278,8 @@ def parseArgs():
     action=EnvAction,
     envvar=gffgene_envvar,
     default=argparse.SUPPRESS,  # removes "(default: None)" from help text
-    help=('The GFF(.gz) file containing gene records (can also be specified using '
-         f'the {gffgene_envvar} environment variable).'))
+    help=('The GFF(.gz) file containing gene records (can also be specified '
+         f'using the {gffgene_envvar} environment variable).'))
   gffchr_envvar = 'CHROMOSOME_GFF_FILE'
   gff_parser.add_argument(
     '--chromosome-gff',
@@ -288,8 +288,8 @@ def parseArgs():
     action=EnvAction,
     envvar=gffchr_envvar,
     default=argparse.SUPPRESS,  # removes "(default: None)" from help text
-    help=('The GFF(.gz) file containing chromosome/supercontig records (can also be '
-         f'specified using the {gffchr_envvar} environment variable).'))
+    help=('The GFF(.gz) file containing chromosome/supercontig records (can '
+        f'also be specified using the {gffchr_envvar} environment variable).'))
   gfa_envvar = 'GFA_FILE'
   gff_parser.add_argument(
     '--gfa',
@@ -297,8 +297,8 @@ def parseArgs():
     action=EnvAction,
     envvar=gfa_envvar,
     default=argparse.SUPPRESS,  # removes "(default: None)" from help text
-    help=('The GFA(.gz) file containing gene-gene family associations (can also be '
-         f'specified using the {gfa_envvar} environment variable).'))
+    help=('The GFA(.gz) file containing gene-gene family associations (can '
+         f'also be specified using the {gfa_envvar} environment variable).'))
 
   return parser.parse_args()
 

--- a/redis_loader/redis_loader/loaders/gff.py
+++ b/redis_loader/redis_loader/loaders/gff.py
@@ -4,6 +4,7 @@ import csv
 from collections import defaultdict
 # dependencies
 import gffutils
+import gzip
 from urllib.request import urlopen, urlparse
 
 
@@ -82,7 +83,8 @@ def transferGenes(redisearch_loader, gene_gff, gfa, chromosome_names):
           gene_lookup[gffgene.id] = gene
           chromosome_genes[chr_name].append(gene)
   # deal with family assignments (for non-orphans) from GFA
-  with (open(gfa, 'rb') if urlparse(gfa).scheme == '' else urlopen(gfa)) as tsv:
+  with (open(gfa, 'rb') if urlparse(gfa).scheme == '' else urlopen(gfa)) as fileobj:
+    tsv = gzip.GzipFile(fileobj=fileobj) if gfa.endswith("gz") else fileobj
     for line in csv.reader(codecs.iterdecode(tsv, 'utf-8'), delimiter="\t"):
       # skip comment and metadata lines
       if line[0].startswith('#') or line[0] == 'ScoreMeaning':

--- a/redis_loader/redis_loader/loaders/gff.py
+++ b/redis_loader/redis_loader/loaders/gff.py
@@ -1,8 +1,10 @@
 # Python
+import codecs
 import csv
 from collections import defaultdict
 # dependencies
 import gffutils
+from urllib.request import urlopen, urlparse
 
 
 def transferChromosomes(redisearch_loader, genus, species, chromosome_gff):
@@ -14,7 +16,7 @@ def transferChromosomes(redisearch_loader, genus, species, chromosome_gff):
       RediSearch.
     genus (str): The genus of the chromosomes being loaded.
     species (str): The species of the chromosomes being loaded.
-    chromosome_gff (pathlib.Path): The path to the GFF to load chromosomes from.
+    chromosome_gff (str): The local path or URL to the GFF to load chromosomes from.
 
   Returns:
     set[str]: A set containing the names of all the chromosomes that were
@@ -24,7 +26,7 @@ def transferChromosomes(redisearch_loader, genus, species, chromosome_gff):
   # create chromosome SQLLite database from chromosomal GFF file
   gffchr_db = \
     gffutils.create_db(
-      str(chromosome_gff),
+      chromosome_gff,
       ':memory:',
       force=True,
       keep_order=True,
@@ -48,8 +50,8 @@ def transferGenes(redisearch_loader, gene_gff, gfa, chromosome_names):
   Parameters:
     redisearch_loader (RediSearchLoader): The loader to use to load data into
       RediSearch.
-    gene_gff (pathlib.Path): The path to the GFF to load genes from.
-    gfa (pathlib.Path): The path to a GFA file containing gene family
+    gene_gff (str): The local path or URL to the GFF to load genes from.
+    gfa (str): The local path or URL to a GFA file containing gene family
       associations for the genes being loaded.
     chromosome_names (set[str]): A containing the names of all the chromosomes
       that have been loaded.
@@ -57,7 +59,7 @@ def transferGenes(redisearch_loader, gene_gff, gfa, chromosome_names):
 
   # create gene SQLLite database from gene GFF file
   gffgene_db = \
-    gffutils.create_db(str(gene_gff), ':memory:', force=True, keep_order=True)
+    gffutils.create_db(gene_gff, ':memory:', force=True, keep_order=True)
 
   # index all the genes in the db
   gene_lookup = dict()
@@ -80,8 +82,8 @@ def transferGenes(redisearch_loader, gene_gff, gfa, chromosome_names):
           gene_lookup[gffgene.id] = gene
           chromosome_genes[chr_name].append(gene)
   # deal with family assignments (for non-orphans) from GFA
-  with gfa.open('r') as tsv:
-    for line in csv.reader(tsv, delimiter="\t"):
+  with (open(gfa, 'rb') if urlparse(gfa).scheme == '' else urlopen(gfa)) as tsv:
+    for line in csv.reader(codecs.iterdecode(tsv, 'utf-8'), delimiter="\t"):
       # skip comment and metadata lines
       if line[0].startswith('#') or line[0] == 'ScoreMeaning':
         continue

--- a/redis_loader/redis_loader/loaders/gff.py
+++ b/redis_loader/redis_loader/loaders/gff.py
@@ -83,7 +83,8 @@ def transferGenes(redisearch_loader, gene_gff, gfa, chromosome_names):
           gene_lookup[gffgene.id] = gene
           chromosome_genes[chr_name].append(gene)
   # deal with family assignments (for non-orphans) from GFA
-  with (open(gfa, 'rb') if urlparse(gfa).scheme == '' else urlopen(gfa)) as fileobj:
+  with (open(gfa, 'rb') if urlparse(gfa).scheme == ''
+                        else urlopen(gfa)) as fileobj:
     tsv = gzip.GzipFile(fileobj=fileobj) if gfa.endswith("gz") else fileobj
     for line in csv.reader(codecs.iterdecode(tsv, 'utf-8'), delimiter="\t"):
       # skip comment and metadata lines


### PR DESCRIPTION
`gffutils.create_db()` supports [loading a file via URL](http://daler.github.io/gffutils/changelog.html#changes-in-v0-8-3). It would be handy to allow the redis_loader to accept `--gene-gff`, `--chromosome-gff`, and `--gfa` option-arguments that are either file pathnames or URLs; this patch attempts to implement that by passing the arguments directly to gffutils.create_db() without first converting them to pathlib.Path objects (which collapses any '//' in URLs to '/').

The handling of urllib.requests.urlopen() encoding may not be the most elegant; it was taken from https://stackoverflow.com/a/18897408 .