### PR TITLE
redis_loader: invoke loader scripts in docker-entrypoint-initdb.d

### DIFF
--- a/redis_loader/Dockerfile
+++ b/redis_loader/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-alpine AS builder
+FROM python:3.9-alpine3.15 AS builder
 
 RUN apk add --no-cache \
   gcc \
@@ -17,12 +17,14 @@ COPY redis_loader/ ./redis_loader/
 
 RUN pip3 install --no-cache-dir .
 
-FROM python:3.9-alpine3.12
+FROM python:3.9-alpine3.15
 
 RUN apk add --no-cache libpq
 
 COPY --from=builder /usr/local/lib/python3.9/site-packages/ /usr/local/lib/python3.9/site-packages/
+COPY ./docker-entrypoint-initdb.d/ /docker-entrypoint-initdb.d/
+COPY ./entrypoint.sh /entrypoint.sh
 
 WORKDIR /app
 
-ENTRYPOINT ["python", "-u", "-m", "redis_loader"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/redis_loader/README.md
+++ b/redis_loader/README.md
@@ -29,7 +29,7 @@ The script loads data into Redis from GFF files or a Chado (PostgreSQL) database
 The credentials for Redis and the different data sources can be set via command line flags or via environment variables.
 The Redis credentials can be provided via the `REDIS_DB`, `REDIS_PASSWORD`, `REDIS_HOST`, and `REDIS_PORT` environment variables.
 The GFF credits can be provided via the `GENUS`, `SPECIES`, `STRAIN`, `GENE_GFF_FILE`, `CHROMOSOME_GFF_FILE`, and `GFA_FILE` environment variables.
-And the Chaddo (PostgreSQL) database credentials can be provided via the `POSTGRES_DATABASE`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_HOST`, and `POSTGRES_PORT` environment variables.
+And the Chado (PostgreSQL) database credentials can be provided via the `POSTGRES_DATABASE`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_HOST`, and `POSTGRES_PORT` environment variables.
 
 The loading script can be run as follows
 
@@ -42,3 +42,7 @@ For more information about the script and additional commands and arguments, run
 If the program was built as a docker container, it can be run as follows
 
     $ docker run redis_loader
+
+Any `*.sh` scripts in the container /docker-entrypoint-initdb.d directory will be processed if the `REDIS_DB` (default 0) at `REDIS_HOST` (default 'localhost') on port `REDIS_PORT` (default 6379) is empty:
+
+    $ docker run -e REDIS_HOST=my-redis-db-host -v $PWD/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d redis_loader

--- a/redis_loader/docker-entrypoint-initdb.d/load.sh.sample
+++ b/redis_loader/docker-entrypoint-initdb.d/load.sh.sample
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -o errexit -o pipefail
+
+wget -O - https://data.legumeinfo.org/Medicago/truncatula/genomes/R108_HM340.gnm1.XT6J/medtr.R108_HM340.gnm1.XT6J.genome_main.fna.gz.fai |
+  awk ' BEGIN { FS=OFS="\t"; print "##gff-version 3" }
+        { 
+            print $1, ".", $1 ~ /scaffold/ ? "supercontig" : "chromosome", 
+                   1, $2, ".", ".", ".", "ID=" $1 ";" "Name=" $1 
+        }' | 
+    python -u -m redis_loader --load-type append gff \
+           --genus Medicago \
+           --species truncatula \
+           --strain R108_HM340 \
+           --gene-gff https://data.legumeinfo.org/Medicago/truncatula/annotations/R108_HM340.gnm1.ann1.85YW/medtr.R108_HM340.gnm1.ann1.85YW.gcv_genes.gff3.gz \
+           --gfa https://data.legumeinfo.org/Medicago/truncatula/annotations/R108_HM340.gnm1.ann1.85YW/medtr.R108_HM340.gnm1.ann1.85YW.legfed_v1_0.M65K.gfa.tsv.gz \
+           --chromosome-gff /dev/stdin
+
+# local file
+# python -u -m redis_loader --load-type append gff --genus Medicago --species truncatula --strain R108_HM340 --gene-gff medtr.R108_HM340.gnm1.ann1.85YW.gcv_genes.gff3.gz --chromosome-gff glyma.58-161.gnm1.BW8J.gcv_genome.gff3 --gfa glyma.58-161.gnm1.ann1.HJ1K.legfed_v1_0.M65K.gfa.tsv
+
+# fetch & load
+# wget https://...
+# python -u -m redis_loader ...

--- a/redis_loader/docker-entrypoint-initdb.d/load.sh.sample
+++ b/redis_loader/docker-entrypoint-initdb.d/load.sh.sample
@@ -5,7 +5,7 @@ set -o errexit -o pipefail
 wget -O - https://data.legumeinfo.org/Medicago/truncatula/genomes/R108_HM340.gnm1.XT6J/medtr.R108_HM340.gnm1.XT6J.genome_main.fna.gz.fai |
   awk ' BEGIN { FS=OFS="\t"; print "##gff-version 3" }
         { 
-            print $1, ".", $1 ~ /scaffold/ ? "supercontig" : "chromosome", 
+            print $1, ".", $1 ~ /\.scf/ ? "supercontig" : "chromosome", 
                    1, $2, ".", ".", ".", "ID=" $1 ";" "Name=" $1 
         }' | 
     python -u -m redis_loader --load-type append gff \

--- a/redis_loader/entrypoint.sh
+++ b/redis_loader/entrypoint.sh
@@ -18,4 +18,7 @@ then
   cd -
 fi
 
-[ $# -gt 0 ] && python -u -m redis_loader "$@"
+if [ $# -gt 0 ] 
+then
+  python -u -m redis_loader "$@"
+fi

--- a/redis_loader/entrypoint.sh
+++ b/redis_loader/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -o errexit
+
+if python <<END
+import sys, redis
+r = redis.Redis(host='${REDIS_HOST:-localhost}',
+                port=${REDIS_PORT:-6379},
+                db=${REDIS_DB:-0})
+sys.exit(min(r.dbsize(), 1))
+END
+then
+  cd /docker-entrypoint-initdb.d
+  for loader_script in *.sh
+  do
+    [ "${loader_script}" != '*.sh' ] && sh "${loader_script}"
+  done
+  cd -
+fi
+
+[ $# -gt 0 ] && python -u -m redis_loader "$@"


### PR DESCRIPTION
Emulate the behavior of the official Docker mysql/mariadb, postgres, and mongo images by invoking scripts in the /docker-entrypoint-initdb.d directory in the redis_loader container if the specified redis database is empty.