### PR TITLE
Add schema version to the Redis database

### DIFF
--- a/redis_loader/redis_loader/__init__.py
+++ b/redis_loader/redis_loader/__init__.py
@@ -1,8 +1,13 @@
 def int_or_str(value):
-    try:
-        return int(value)
-    except ValueError:
-        return value
+  try:
+    return int(value)
+  except ValueError:
+    return value
 
 __version__ = '1.1.0'
 VERSION = tuple(map(int_or_str, __version__.split('.')))
+
+__schema_version__ = '1.0.0'
+SCHEMA_VERSION = tuple(map(int_or_str, __schema_version__.split('.')))
+
+__compatible_schema_versions__ = [__schema_version__]

--- a/redis_loader/redis_loader/__main__.py
+++ b/redis_loader/redis_loader/__main__.py
@@ -86,7 +86,7 @@ def parseArgs():
   parser.add_argument(
     '--version',
     action='version',
-    version=f'%(prog)s {redis_loader.__version__}',
+    version=f'%(prog)s {redis_loader.__version__} schema {redis_loader.__schema_version__}',
   )
   subparsers = \
     parser.add_subparsers(title='commands', dest='command', required=True)


### PR DESCRIPTION
The Redis loader now stores the schema version in the database as well as a list of compatible schema versions so schemas can be backwards compatible, i.e. there's a deprecation period for old schema versions. The loader now checks that the schema version in the database matches the version it loads when the load type is append (the default) and throws an error if they don't match.