### PR TITLE
uvloop initialization syntax

### DIFF
--- a/chromosome/chromosome/__main__.py
+++ b/chromosome/chromosome/__main__.py
@@ -95,8 +95,8 @@ def main():
     exit('--no-http and --no-grpc can\'t both be given')
 
   # initialize asyncio
-  uvloop.install()
-  loop = asyncio.get_event_loop()
+  loop = uvloop.new_event_loop()
+  asyncio.set_event_loop(loop)
 
   # run the program
   loop.create_task(main_coroutine(args))

--- a/chromosome_region/chromosome_region/__main__.py
+++ b/chromosome_region/chromosome_region/__main__.py
@@ -92,8 +92,8 @@ def main():
     exit('--no-http and --no-grpc can\'t both be given')
 
   # initialize asyncio
-  uvloop.install()
-  loop = asyncio.get_event_loop()
+  loop = uvloop.new_event_loop()
+  asyncio.set_event_loop(loop)
 
   # run the program
   loop.create_task(main_coroutine(args))

--- a/chromosome_search/chromosome_search/__main__.py
+++ b/chromosome_search/chromosome_search/__main__.py
@@ -92,8 +92,8 @@ def main():
     exit('--no-http and --no-grpc can\'t both be given')
 
   # initialize asyncio
-  uvloop.install()
-  loop = asyncio.get_event_loop()
+  loop = uvloop.new_event_loop()
+  asyncio.set_event_loop(loop)
 
   # run the program
   loop.create_task(main_coroutine(args))

--- a/gene_search/gene_search/__main__.py
+++ b/gene_search/gene_search/__main__.py
@@ -93,8 +93,8 @@ def main():
     exit('--no-http and --no-grpc can\'t both be given')
 
   # initialize asyncio
-  uvloop.install()
-  loop = asyncio.get_event_loop()
+  loop = uvloop.new_event_loop()
+  asyncio.set_event_loop(loop)
 
   # run the program
   loop.create_task(main_coroutine(args))

--- a/genes/genes/__main__.py
+++ b/genes/genes/__main__.py
@@ -93,8 +93,8 @@ def main():
     exit('--no-http and --no-grpc can\'t both be given')
 
   # initialize asyncio
-  uvloop.install()
-  loop = asyncio.get_event_loop()
+  loop = uvloop.new_event_loop()
+  asyncio.set_event_loop(loop)
 
   # run the program
   loop.create_task(main_coroutine(args))

--- a/macro_synteny_blocks/macro_synteny_blocks/__main__.py
+++ b/macro_synteny_blocks/macro_synteny_blocks/__main__.py
@@ -97,8 +97,8 @@ def main():
     exit('--no-http and --no-grpc can\'t both be given')
 
   # initialize asyncio
-  uvloop.install()
-  loop = asyncio.get_event_loop()
+  loop = uvloop.new_event_loop()
+  asyncio.set_event_loop(loop)
 
   # run the program
   loop.create_task(main_coroutine(args))

--- a/micro_synteny_search/micro_synteny_search/__main__.py
+++ b/micro_synteny_search/micro_synteny_search/__main__.py
@@ -93,8 +93,8 @@ def main():
     exit('--no-http and --no-grpc can\'t both be given')
 
   # initialize asyncio
-  uvloop.install()
-  loop = asyncio.get_event_loop()
+  loop = uvloop.new_event_loop()
+  asyncio.set_event_loop(loop)
 
   # run the program
   loop.create_task(main_coroutine(args))

--- a/pairwise_macro_synteny_blocks/pairwise_macro_synteny_blocks/__main__.py
+++ b/pairwise_macro_synteny_blocks/pairwise_macro_synteny_blocks/__main__.py
@@ -93,8 +93,8 @@ def main():
     exit('--no-http and --no-grpc can\'t both be given')
 
   # initialize asyncio
-  uvloop.install()
-  loop = asyncio.get_event_loop()
+  loop = uvloop.new_event_loop()
+  asyncio.set_event_loop(loop)
 
   # run the program
   loop.create_task(main_coroutine(args))

--- a/search/search/__main__.py
+++ b/search/search/__main__.py
@@ -94,8 +94,8 @@ def main():
     exit('--no-http and --no-grpc can\'t both be given')
 
   # initialize asyncio
-  uvloop.install()
-  loop = asyncio.get_event_loop()
+  loop = uvloop.new_event_loop()
+  asyncio.set_event_loop(loop)
 
   # run the program
   loop.create_task(main_coroutine(args))


### PR DESCRIPTION
The uvloop initialization syntax being used by the microservices was deprecated. This PR updates the services to use the most recent syntax.