### PR TITLE
Exception handling and graceful shutdowns

### DIFF
--- a/chromosome/chromosome/__main__.py
+++ b/chromosome/chromosome/__main__.py
@@ -5,6 +5,8 @@ import argparse
 import asyncio
 import logging
 import os
+import signal
+# dependencies
 import uvloop
 # module
 import chromosome
@@ -104,20 +106,26 @@ def parseArgs():
   return parser.parse_args()
 
 
-# the main coroutine that starts the various program tasks
-async def main_coroutine(args):
-  redis_connection = await connectToRedis(args.rhost, args.rport, args.rdb, args.rpassword)
-  handler = RequestHandler(redis_connection)
-  tasks = []
-  if not args.nohttp:
-    http_coro = run_http_server(args.hhost, args.hport, handler)
-    http_task = asyncio.create_task(http_coro)
-    tasks.append(http_task)
-  if not args.nogrpc:
-    grpc_coro = run_grpc_server(args.ghost, args.gport, handler)
-    grpc_task = asyncio.create_task(grpc_coro)
-    tasks.append(grpc_task)
-  await asyncio.gather(*tasks)
+# graceful shutdown
+async def shutdown(loop, signal=None):
+  # report what signal (if any) initiated the shutdown
+  if signal:
+    logging.info(f'Received exit signal {signal.name}')
+  # cancel all running tasks (they know how to cleanup themselves)
+  logging.info('Cancelling outstanding tasks')
+  tasks = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+  [task.cancel() for task in tasks]
+  await asyncio.gather(*tasks, return_exceptions=True)
+  # stop the asyncio loop
+  loop.stop()
+
+
+# the asyncio exception handler that will initiate a shutdown
+def handleException(loop, context):
+  msg = context.get('exception', context['message'])
+  logging.critical(f'Caught exception: {msg}')
+  logging.info('Shutting down')
+  asyncio.create_task(shutdown(loop))
 
 
 def main():
@@ -129,6 +137,8 @@ def main():
 
   # setup logging
   log_config = {
+      'format': '%(asctime)s,%(msecs)d %(levelname)s: %(message)s',
+      'datefmt': '%H:%M:%S',
       'level': LOG_LEVELS[args.log_level],
     }
   if 'log_file' in args:
@@ -139,9 +149,36 @@ def main():
   loop = uvloop.new_event_loop()
   asyncio.set_event_loop(loop)
 
+  # setup asyncio exception handling
+  signals = (signal.SIGHUP, signal.SIGTERM, signal.SIGINT)
+  for s in signals:
+    loop.add_signal_handler(
+      s, lambda s=s: loop.create_task(shutdown(loop, signal=s))
+    )
+  loop.set_exception_handler(handleException)
+
   # run the program
-  loop.create_task(main_coroutine(args))
-  loop.run_forever()
+  try:
+    # create the database connection
+    redis_connection = loop.run_until_complete(connectToRedis(args.rhost, args.rport, args.rdb, args.rpassword))
+    # create the request handler
+    handler = RequestHandler(redis_connection)
+    # start the HTTP server
+    if not args.nohttp:
+      loop.create_task(run_http_server(args.hhost, args.hport, handler))
+    # start the gRPC server
+    if not args.nogrpc:
+      loop.create_task(run_grpc_server(args.ghost, args.gport, handler))
+    # run the main loop
+    loop.run_forever()
+  # catch exceptions not handled by asyncio
+  except Exception as e:
+    context = {'exception': e, 'message': str(e)}
+    loop.call_exception_handler(context)
+  # finalize the shutdown
+  finally:
+    loop.close()
+    logging.info('Successfully shutdown.')
 
 
 if __name__ == '__main__':

--- a/chromosome/chromosome/grpc_server.py
+++ b/chromosome/chromosome/grpc_server.py
@@ -13,10 +13,17 @@ class Chromosome(chromosome_pb2_grpc.ChromosomeServicer):
   def __init__(self, handler):
     self.handler = handler
 
-  async def Get(self, request, context):
+  # create a context done callback that raises the given exception
+  def _exceptionCallbackFactory(self, exception):
+    def exceptionCallback(call):
+      raise exception
+    return exceptionCallback
+
+  # the method that actually handles requests
+  async def _get(self, request, context):
     chromosome = await self.handler.process(request.name)
     if chromosome is None:
-      # raise a gRPC NOT FOUND error
+      # return a gRPC NOT FOUND error
       await context.abort(grpc.StatusCode.NOT_FOUND, 'Chromosome not found')
     return chromosome_pb2.ChromosomeGetReply(
       chromosome=track_pb2.Chromosome(
@@ -30,6 +37,23 @@ class Chromosome(chromosome_pb2_grpc.ChromosomeServicer):
       )
     )
 
+  # implements the service's API
+  async def Get(self, request, context):
+    # subvert the gRPC exception handler via a try/except block
+    try:
+      return await self._get(request, context)
+    # let errors we raised go by
+    except aio.AbortError as e:
+      raise e
+    # raise an internal error to prevent internal info from being sent to users
+    except Exception as e:
+      # raise the exception after aborting so it gets logged
+      # NOTE: gRPC docs says abort should raise an error but it doesn't...
+      context.add_done_callback(self._exceptionCallbackFactory(e))
+      # return a gRPC INTERNAL error
+      await context.abort(grpc.StatusCode.INTERNAL, 'Internal server error')
+
+
 
 async def run_grpc_server(host, port, handler):
   server = aio.server()
@@ -38,3 +62,4 @@ async def run_grpc_server(host, port, handler):
   chromosome_pb2_grpc.add_ChromosomeServicer_to_server(servicer, server)
   await server.start()
   await server.wait_for_termination()
+  # TODO: what about teardown? server.stop(None)

--- a/chromosome_region/chromosome_region/__main__.py
+++ b/chromosome_region/chromosome_region/__main__.py
@@ -5,6 +5,8 @@ import argparse
 import asyncio
 import logging
 import os
+import signal
+# dependencies
 import uvloop
 # module
 import chromosome_region
@@ -103,18 +105,26 @@ def parseArgs():
   return parser.parse_args()
 
 
-# the main coroutine that starts the various program tasks
-async def main_coroutine(args):
-  redis_connection = await connectToRedis(args.rhost, args.rport, args.rdb, args.rpassword)
-  handler = RequestHandler(redis_connection)
-  tasks = []
-  if not args.nohttp:
-    http_task = asyncio.create_task(run_http_server(args.hhost, args.hport, handler))
-    tasks.append(http_task)
-  if not args.nogrpc:
-    grpc_task = asyncio.create_task(run_grpc_server(args.ghost, args.gport, handler))
-    tasks.append(grpc_task)
-  await asyncio.gather(*tasks)
+# graceful shutdown
+async def shutdown(loop, signal=None):
+  # report what signal (if any) initiated the shutdown
+  if signal:
+    logging.info(f'Received exit signal {signal.name}')
+  # cancel all running tasks (they know how to cleanup themselves)
+  logging.info('Cancelling outstanding tasks')
+  tasks = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+  [task.cancel() for task in tasks]
+  await asyncio.gather(*tasks, return_exceptions=True)
+  # stop the asyncio loop
+  loop.stop()
+
+
+# the asyncio exception handler that will initiate a shutdown
+def handleException(loop, context):
+  msg = context.get('exception', context['message'])
+  logging.critical(f'Caught exception: {msg}')
+  logging.info('Shutting down')
+  asyncio.create_task(shutdown(loop))
 
 
 def main():
@@ -126,6 +136,8 @@ def main():
 
   # setup logging
   log_config = {
+      'format': '%(asctime)s,%(msecs)d %(levelname)s: %(message)s',
+      'datefmt': '%H:%M:%S',
       'level': LOG_LEVELS[args.log_level],
     }
   if 'log_file' in args:
@@ -136,9 +148,36 @@ def main():
   loop = uvloop.new_event_loop()
   asyncio.set_event_loop(loop)
 
+  # setup asyncio exception handling
+  signals = (signal.SIGHUP, signal.SIGTERM, signal.SIGINT)
+  for s in signals:
+    loop.add_signal_handler(
+      s, lambda s=s: loop.create_task(shutdown(loop, signal=s))
+    )
+  loop.set_exception_handler(handleException)
+
   # run the program
-  loop.create_task(main_coroutine(args))
-  loop.run_forever()
+  try:
+    # create the database connection
+    redis_connection = loop.run_until_complete(connectToRedis(args.rhost, args.rport, args.rdb, args.rpassword))
+    # create the request handler
+    handler = RequestHandler(redis_connection)
+    # start the HTTP server
+    if not args.nohttp:
+      loop.create_task(run_http_server(args.hhost, args.hport, handler))
+    # start the gRPC server
+    if not args.nogrpc:
+      loop.create_task(run_grpc_server(args.ghost, args.gport, handler))
+    # run the main loop
+    loop.run_forever()
+  # catch exceptions not handled by asyncio
+  except Exception as e:
+    context = {'exception': e, 'message': str(e)}
+    loop.call_exception_handler(context)
+  # finalize the shutdown
+  finally:
+    loop.close()
+    logging.info('Successfully shutdown.')
 
 
 if __name__ == '__main__':

--- a/chromosome_search/chromosome_search/__main__.py
+++ b/chromosome_search/chromosome_search/__main__.py
@@ -5,6 +5,8 @@ import argparse
 import asyncio
 import logging
 import os
+import signal
+# dependencies
 import uvloop
 # module
 import chromosome_search
@@ -104,18 +106,26 @@ def parseArgs():
   return parser.parse_args()
 
 
-# the main coroutine that starts the various program tasks
-async def main_coroutine(args):
-  redis_connection = await connectToRedis(args.rhost, args.rport, args.rdb, args.rpassword)
-  handler = RequestHandler(redis_connection)
-  tasks = []
-  if not args.nohttp:
-    http_task = asyncio.create_task(run_http_server(args.hhost, args.hport, handler))
-    tasks.append(http_task)
-  if not args.nogrpc:
-    grpc_task = asyncio.create_task(run_grpc_server(args.ghost, args.gport, handler))
-    tasks.append(grpc_task)
-  await asyncio.gather(*tasks)
+# graceful shutdown
+async def shutdown(loop, signal=None):
+  # report what signal (if any) initiated the shutdown
+  if signal:
+    logging.info(f'Received exit signal {signal.name}')
+  # cancel all running tasks (they know how to cleanup themselves)
+  logging.info('Cancelling outstanding tasks')
+  tasks = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+  [task.cancel() for task in tasks]
+  await asyncio.gather(*tasks, return_exceptions=True)
+  # stop the asyncio loop
+  loop.stop()
+
+
+# the asyncio exception handler that will initiate a shutdown
+def handleException(loop, context):
+  msg = context.get('exception', context['message'])
+  logging.critical(f'Caught exception: {msg}')
+  logging.info('Shutting down')
+  asyncio.create_task(shutdown(loop))
 
 
 def main():
@@ -127,6 +137,8 @@ def main():
 
   # setup logging
   log_config = {
+      'format': '%(asctime)s,%(msecs)d %(levelname)s: %(message)s',
+      'datefmt': '%H:%M:%S',
       'level': LOG_LEVELS[args.log_level],
     }
   if 'log_file' in args:
@@ -137,9 +149,36 @@ def main():
   loop = uvloop.new_event_loop()
   asyncio.set_event_loop(loop)
 
+  # setup asyncio exception handling
+  signals = (signal.SIGHUP, signal.SIGTERM, signal.SIGINT)
+  for s in signals:
+    loop.add_signal_handler(
+      s, lambda s=s: loop.create_task(shutdown(loop, signal=s))
+    )
+  loop.set_exception_handler(handleException)
+
   # run the program
-  loop.create_task(main_coroutine(args))
-  loop.run_forever()
+  try:
+    # create the database connection
+    redis_connection = loop.run_until_complete(connectToRedis(args.rhost, args.rport, args.rdb, args.rpassword))
+    # create the request handler
+    handler = RequestHandler(redis_connection)
+    # start the HTTP server
+    if not args.nohttp:
+      loop.create_task(run_http_server(args.hhost, args.hport, handler))
+    # start the gRPC server
+    if not args.nogrpc:
+      loop.create_task(run_grpc_server(args.ghost, args.gport, handler))
+    # run the main loop
+    loop.run_forever()
+  # catch exceptions not handled by asyncio
+  except Exception as e:
+    context = {'exception': e, 'message': str(e)}
+    loop.call_exception_handler(context)
+  # finalize the shutdown
+  finally:
+    loop.close()
+    logging.info('Successfully shutdown.')
 
 
 if __name__ == '__main__':

--- a/gene_search/gene_search/__main__.py
+++ b/gene_search/gene_search/__main__.py
@@ -5,6 +5,8 @@ import argparse
 import asyncio
 import logging
 import os
+import signal
+# dependencies
 import uvloop
 # module
 import gene_search
@@ -104,18 +106,26 @@ def parseArgs():
   return parser.parse_args()
 
 
-# the main coroutine that starts the various program tasks
-async def main_coroutine(args):
-  redis_connection = await connectToRedis(args.rhost, args.rport, args.rdb, args.rpassword)
-  handler = RequestHandler(redis_connection)
-  tasks = []
-  if not args.nohttp:
-    http_task = asyncio.create_task(run_http_server(args.hhost, args.hport, handler))
-    tasks.append(http_task)
-  if not args.nogrpc:
-    grpc_task = asyncio.create_task(run_grpc_server(args.ghost, args.gport, handler))
-    tasks.append(grpc_task)
-  await asyncio.gather(*tasks)
+# graceful shutdown
+async def shutdown(loop, signal=None):
+  # report what signal (if any) initiated the shutdown
+  if signal:
+    logging.info(f'Received exit signal {signal.name}')
+  # cancel all running tasks (they know how to cleanup themselves)
+  logging.info('Cancelling outstanding tasks')
+  tasks = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+  [task.cancel() for task in tasks]
+  await asyncio.gather(*tasks, return_exceptions=True)
+  # stop the asyncio loop
+  loop.stop()
+
+
+# the asyncio exception handler that will initiate a shutdown
+def handleException(loop, context):
+  msg = context.get('exception', context['message'])
+  logging.critical(f'Caught exception: {msg}')
+  logging.info('Shutting down')
+  asyncio.create_task(shutdown(loop))
 
 
 def main():
@@ -127,6 +137,8 @@ def main():
 
   # setup logging
   log_config = {
+      'format': '%(asctime)s,%(msecs)d %(levelname)s: %(message)s',
+      'datefmt': '%H:%M:%S',
       'level': LOG_LEVELS[args.log_level],
     }
   if 'log_file' in args:
@@ -137,9 +149,36 @@ def main():
   loop = uvloop.new_event_loop()
   asyncio.set_event_loop(loop)
 
+  # setup asyncio exception handling
+  signals = (signal.SIGHUP, signal.SIGTERM, signal.SIGINT)
+  for s in signals:
+    loop.add_signal_handler(
+      s, lambda s=s: loop.create_task(shutdown(loop, signal=s))
+    )
+  loop.set_exception_handler(handleException)
+
   # run the program
-  loop.create_task(main_coroutine(args))
-  loop.run_forever()
+  try:
+    # create the database connection
+    redis_connection = loop.run_until_complete(connectToRedis(args.rhost, args.rport, args.rdb, args.rpassword))
+    # create the request handler
+    handler = RequestHandler(redis_connection)
+    # start the HTTP server
+    if not args.nohttp:
+      loop.create_task(run_http_server(args.hhost, args.hport, handler))
+    # start the gRPC server
+    if not args.nogrpc:
+      loop.create_task(run_grpc_server(args.ghost, args.gport, handler))
+    # run the main loop
+    loop.run_forever()
+  # catch exceptions not handled by asyncio
+  except Exception as e:
+    context = {'exception': e, 'message': str(e)}
+    loop.call_exception_handler(context)
+  # finalize the shutdown
+  finally:
+    loop.close()
+    logging.info('Successfully shutdown.')
 
 
 if __name__ == '__main__':

--- a/gene_search/gene_search/grpc_server.py
+++ b/gene_search/gene_search/grpc_server.py
@@ -1,4 +1,5 @@
 # dependencies
+import grpc
 from grpc.experimental import aio
 # module
 from gene_search.proto.genesearch_service.v1 import genesearch_pb2
@@ -10,9 +11,32 @@ class GeneSearch(genesearch_pb2_grpc.GeneSearchServicer):
   def __init__(self, handler):
     self.handler = handler
 
-  async def Search(self, request, context):
+  # create a context done callback that raises the given exception
+  def _exceptionCallbackFactory(self, exception):
+    def exceptionCallback(call):
+      raise exception
+    return exceptionCallback
+
+  # the method that actually handles requests
+  async def _search(self, request, context):
     genes = await self.handler.process(request.query)
     return genesearch_pb2.GeneSearchReply(genes=genes)
+
+  # implements the service's API
+  async def Search(self, request, context):
+    # subvert the gRPC exception handler via a try/except block
+    try:
+      return await self._search(request, context)
+    # let errors we raised go by
+    except aio.AbortError as e:
+      raise e
+    # raise an internal error to prevent non-gRPC info from being sent to users
+    except Exception as e:
+      # raise the exception after aborting so it gets logged
+      # NOTE: gRPC docs says abort should raise an error but it doesn't...
+      context.add_done_callback(self._exceptionCallbackFactory(e))
+      # return a gRPC INTERNAL error
+      await context.abort(grpc.StatusCode.INTERNAL, 'Internal server error')
 
 
 async def run_grpc_server(host, port, handler):
@@ -22,3 +46,4 @@ async def run_grpc_server(host, port, handler):
   genesearch_pb2_grpc.add_GeneSearchServicer_to_server(servicer, server)
   await server.start()
   await server.wait_for_termination()
+  # TODO: what about teardown? server.stop(None)

--- a/genes/genes/__main__.py
+++ b/genes/genes/__main__.py
@@ -5,6 +5,8 @@ import argparse
 import asyncio
 import logging
 import os
+import signal
+# dependencies
 import uvloop
 # module
 import genes
@@ -104,18 +106,26 @@ def parseArgs():
   return parser.parse_args()
 
 
-# the main coroutine that starts the various program tasks
-async def main_coroutine(args):
-  redis_connection = await connectToRedis(args.rhost, args.rport, args.rdb, args.rpassword)
-  handler = RequestHandler(redis_connection)
-  tasks = []
-  if not args.nohttp:
-    http_task = asyncio.create_task(run_http_server(args.hhost, args.hport, handler))
-    tasks.append(http_task)
-  if not args.nogrpc:
-    grpc_task = asyncio.create_task(run_grpc_server(args.ghost, args.gport, handler))
-    tasks.append(grpc_task)
-  await asyncio.gather(*tasks)
+# graceful shutdown
+async def shutdown(loop, signal=None):
+  # report what signal (if any) initiated the shutdown
+  if signal:
+    logging.info(f'Received exit signal {signal.name}')
+  # cancel all running tasks (they know how to cleanup themselves)
+  logging.info('Cancelling outstanding tasks')
+  tasks = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+  [task.cancel() for task in tasks]
+  await asyncio.gather(*tasks, return_exceptions=True)
+  # stop the asyncio loop
+  loop.stop()
+
+
+# the asyncio exception handler that will initiate a shutdown
+def handleException(loop, context):
+  msg = context.get('exception', context['message'])
+  logging.critical(f'Caught exception: {msg}')
+  logging.info('Shutting down')
+  asyncio.create_task(shutdown(loop))
 
 
 def main():
@@ -127,6 +137,8 @@ def main():
 
   # setup logging
   log_config = {
+      'format': '%(asctime)s,%(msecs)d %(levelname)s: %(message)s',
+      'datefmt': '%H:%M:%S',
       'level': LOG_LEVELS[args.log_level],
     }
   if 'log_file' in args:
@@ -137,9 +149,36 @@ def main():
   loop = uvloop.new_event_loop()
   asyncio.set_event_loop(loop)
 
+  # setup asyncio exception handling
+  signals = (signal.SIGHUP, signal.SIGTERM, signal.SIGINT)
+  for s in signals:
+    loop.add_signal_handler(
+      s, lambda s=s: loop.create_task(shutdown(loop, signal=s))
+    )
+  loop.set_exception_handler(handleException)
+
   # run the program
-  loop.create_task(main_coroutine(args))
-  loop.run_forever()
+  try:
+    # create the database connection
+    redis_connection = loop.run_until_complete(connectToRedis(args.rhost, args.rport, args.rdb, args.rpassword))
+    # create the request handler
+    handler = RequestHandler(redis_connection)
+    # start the HTTP server
+    if not args.nohttp:
+      loop.create_task(run_http_server(args.hhost, args.hport, handler))
+    # start the gRPC server
+    if not args.nogrpc:
+      loop.create_task(run_grpc_server(args.ghost, args.gport, handler))
+    # run the main loop
+    loop.run_forever()
+  # catch exceptions not handled by asyncio
+  except Exception as e:
+    context = {'exception': e, 'message': str(e)}
+    loop.call_exception_handler(context)
+  # finalize the shutdown
+  finally:
+    loop.close()
+    logging.info('Successfully shutdown.')
 
 
 if __name__ == '__main__':

--- a/genes/genes/grpc_server.py
+++ b/genes/genes/grpc_server.py
@@ -1,4 +1,5 @@
 # dependencies
+import grpc
 from grpc.experimental import aio
 # module
 from genes.proto.genes_service.v1 import genes_pb2
@@ -11,7 +12,14 @@ class Genes(genes_pb2_grpc.GenesServicer):
   def __init__(self, handler):
     self.handler = handler
 
-  async def Get(self, request, context):
+  # create a context done callback that raises the given exception
+  def _exceptionCallbackFactory(self, exception):
+    def exceptionCallback(call):
+      raise exception
+    return exceptionCallback
+
+  # the method that actually handles requests
+  async def _get(self, request, context):
     genes = await self.handler.process(request.names)
     gene_messages = list(map(lambda g:
       gene_pb2.Gene(
@@ -24,6 +32,22 @@ class Genes(genes_pb2_grpc.GenesServicer):
       ), genes))
     return genes_pb2.GenesGetReply(genes=gene_messages)
 
+  # implements the service's API
+  async def Get(self, request, context):
+    # subvert the gRPC exception handler via a try/except block
+    try:
+      return await self._get(request, context)
+    # let errors we raised go by
+    except aio.AbortError as e:
+      raise e
+    # raise an internal error to prevent non-gRPC info from being sent to users
+    except Exception as e:
+      # raise the exception after aborting so it gets logged
+      # NOTE: gRPC docs says abort should raise an error but it doesn't...
+      context.add_done_callback(self._exceptionCallbackFactory(e))
+      # return a gRPC INTERNAL error
+      await context.abort(grpc.StatusCode.INTERNAL, 'Internal server error')
+
 
 async def run_grpc_server(host, port, handler):
   server = aio.server()
@@ -32,3 +56,4 @@ async def run_grpc_server(host, port, handler):
   genes_pb2_grpc.add_GenesServicer_to_server(servicer, server)
   await server.start()
   await server.wait_for_termination()
+  # TODO: what about teardown? server.stop(None)

--- a/macro_synteny_blocks/macro_synteny_blocks/__main__.py
+++ b/macro_synteny_blocks/macro_synteny_blocks/__main__.py
@@ -5,6 +5,8 @@ import argparse
 import asyncio
 import logging
 import os
+import signal
+# dependencies
 import uvloop
 # module
 import macro_synteny_blocks
@@ -108,18 +110,26 @@ def parseArgs():
   return parser.parse_args()
 
 
-# the main coroutine that starts the various program tasks
-async def main_coroutine(args):
-  redis_connection = await connectToRedis(args.rhost, args.rport, args.rdb, args.rpassword)
-  handler = RequestHandler(redis_connection, args.pairwiseaddr)
-  tasks = []
-  if not args.nohttp:
-    http_task = asyncio.create_task(run_http_server(args.hhost, args.hport, handler))
-    tasks.append(http_task)
-  if not args.nogrpc:
-    grpc_task = asyncio.create_task(run_grpc_server(args.ghost, args.gport, handler))
-    tasks.append(grpc_task)
-  await asyncio.gather(*tasks)
+# graceful shutdown
+async def shutdown(loop, signal=None):
+  # report what signal (if any) initiated the shutdown
+  if signal:
+    logging.info(f'Received exit signal {signal.name}')
+  # cancel all running tasks (they know how to cleanup themselves)
+  logging.info('Cancelling outstanding tasks')
+  tasks = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+  [task.cancel() for task in tasks]
+  await asyncio.gather(*tasks, return_exceptions=True)
+  # stop the asyncio loop
+  loop.stop()
+
+
+# the asyncio exception handler that will initiate a shutdown
+def handleException(loop, context):
+  msg = context.get('exception', context['message'])
+  logging.critical(f'Caught exception: {msg}')
+  logging.info('Shutting down')
+  asyncio.create_task(shutdown(loop))
 
 
 def main():
@@ -131,6 +141,8 @@ def main():
 
   # setup logging
   log_config = {
+      'format': '%(asctime)s,%(msecs)d %(levelname)s: %(message)s',
+      'datefmt': '%H:%M:%S',
       'level': LOG_LEVELS[args.log_level],
     }
   if 'log_file' in args:
@@ -141,9 +153,36 @@ def main():
   loop = uvloop.new_event_loop()
   asyncio.set_event_loop(loop)
 
+  # setup asyncio exception handling
+  signals = (signal.SIGHUP, signal.SIGTERM, signal.SIGINT)
+  for s in signals:
+    loop.add_signal_handler(
+      s, lambda s=s: loop.create_task(shutdown(loop, signal=s))
+    )
+  loop.set_exception_handler(handleException)
+
   # run the program
-  loop.create_task(main_coroutine(args))
-  loop.run_forever()
+  try:
+    # create the database connection
+    redis_connection = loop.run_until_complete(connectToRedis(args.rhost, args.rport, args.rdb, args.rpassword))
+    # create the request handler
+    handler = RequestHandler(redis_connection, args.pairwiseaddr)
+    # start the HTTP server
+    if not args.nohttp:
+      loop.create_task(run_http_server(args.hhost, args.hport, handler))
+    # start the gRPC server
+    if not args.nogrpc:
+      loop.create_task(run_grpc_server(args.ghost, args.gport, handler))
+    # run the main loop
+    loop.run_forever()
+  # catch exceptions not handled by asyncio
+  except Exception as e:
+    context = {'exception': e, 'message': str(e)}
+    loop.call_exception_handler(context)
+  # finalize the shutdown
+  finally:
+    loop.close()
+    logging.info('Successfully shutdown.')
 
 
 if __name__ == '__main__':

--- a/macro_synteny_blocks/macro_synteny_blocks/grpc_server.py
+++ b/macro_synteny_blocks/macro_synteny_blocks/grpc_server.py
@@ -11,7 +11,14 @@ class MacroSyntenyBlocks(macrosyntenyblocks_pb2_grpc.MacroSyntenyBlocksServicer)
   def __init__(self, handler):
     self.handler = handler
 
-  async def Compute(self, request, context):
+  # create a context done callback that raises the given exception
+  def _exceptionCallbackFactory(self, exception):
+    def exceptionCallback(call):
+      raise exception
+    return exceptionCallback
+
+  # the method that actually handles requests
+  async def _compute(self, request, context):
     # required parameters
     chromosome = request.chromosome
     matched = request.matched
@@ -31,6 +38,22 @@ class MacroSyntenyBlocks(macrosyntenyblocks_pb2_grpc.MacroSyntenyBlocksServicer)
     blocks = await self.handler.process(chromosome, matched, intermediate, mask, targets, metrics, chromosome_genes, chromosome_length)
     return macrosyntenyblocks_pb2.MacroSyntenyBlocksComputeReply(blocks=blocks)
 
+  # implements the service's API
+  async def Compute(self, request, context):
+    # subvert the gRPC exception handler via a try/except block
+    try:
+      return await self._compute(request, context)
+    # let errors we raised go by
+    except aio.AbortError as e:
+      raise e
+    # raise an internal error to prevent non-gRPC info from being sent to users
+    except Exception as e:
+      # raise the exception after aborting so it gets logged
+      # NOTE: gRPC docs says abort should raise an error but it doesn't...
+      context.add_done_callback(self._exceptionCallbackFactory(e))
+      # return a gRPC INTERNAL error
+      await context.abort(grpc.StatusCode.INTERNAL, 'Internal server error')
+
 
 async def run_grpc_server(host, port, handler):
   server = aio.server()
@@ -39,3 +62,4 @@ async def run_grpc_server(host, port, handler):
   macrosyntenyblocks_pb2_grpc.add_MacroSyntenyBlocksServicer_to_server(servicer, server)
   await server.start()
   await server.wait_for_termination()
+  # TODO: what about teardown? server.stop(None)

--- a/micro_synteny_search/micro_synteny_search/__main__.py
+++ b/micro_synteny_search/micro_synteny_search/__main__.py
@@ -5,6 +5,8 @@ import argparse
 import asyncio
 import logging
 import os
+import signal
+# dependencies
 import uvloop
 # module
 import micro_synteny_search
@@ -104,18 +106,26 @@ def parseArgs():
   return parser.parse_args()
 
 
-# the main coroutine that starts the various program tasks
-async def main_coroutine(args):
-  redis_connection = await connectToRedis(args.rhost, args.rport, args.rdb, args.rpassword)
-  handler = RequestHandler(redis_connection)
-  tasks = []
-  if not args.nohttp:
-    http_task = asyncio.create_task(run_http_server(args.hhost, args.hport, handler))
-    tasks.append(http_task)
-  if not args.nogrpc:
-    grpc_task = asyncio.create_task(run_grpc_server(args.ghost, args.gport, handler))
-    tasks.append(grpc_task)
-  await asyncio.gather(*tasks)
+# graceful shutdown
+async def shutdown(loop, signal=None):
+  # report what signal (if any) initiated the shutdown
+  if signal:
+    logging.info(f'Received exit signal {signal.name}')
+  # cancel all running tasks (they know how to cleanup themselves)
+  logging.info('Cancelling outstanding tasks')
+  tasks = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+  [task.cancel() for task in tasks]
+  await asyncio.gather(*tasks, return_exceptions=True)
+  # stop the asyncio loop
+  loop.stop()
+
+
+# the asyncio exception handler that will initiate a shutdown
+def handleException(loop, context):
+  msg = context.get('exception', context['message'])
+  logging.critical(f'Caught exception: {msg}')
+  logging.info('Shutting down')
+  asyncio.create_task(shutdown(loop))
 
 
 def main():
@@ -127,6 +137,8 @@ def main():
 
   # setup logging
   log_config = {
+      'format': '%(asctime)s,%(msecs)d %(levelname)s: %(message)s',
+      'datefmt': '%H:%M:%S',
       'level': LOG_LEVELS[args.log_level],
     }
   if 'log_file' in args:
@@ -137,9 +149,36 @@ def main():
   loop = uvloop.new_event_loop()
   asyncio.set_event_loop(loop)
 
+  # setup asyncio exception handling
+  signals = (signal.SIGHUP, signal.SIGTERM, signal.SIGINT)
+  for s in signals:
+    loop.add_signal_handler(
+      s, lambda s=s: loop.create_task(shutdown(loop, signal=s))
+    )
+  loop.set_exception_handler(handleException)
+
   # run the program
-  loop.create_task(main_coroutine(args))
-  loop.run_forever()
+  try:
+    # create the database connection
+    redis_connection = loop.run_until_complete(connectToRedis(args.rhost, args.rport, args.rdb, args.rpassword))
+    # create the request handler
+    handler = RequestHandler(redis_connection)
+    # start the HTTP server
+    if not args.nohttp:
+      loop.create_task(run_http_server(args.hhost, args.hport, handler))
+    # start the gRPC server
+    if not args.nogrpc:
+      loop.create_task(run_grpc_server(args.ghost, args.gport, handler))
+    # run the main loop
+    loop.run_forever()
+  # catch exceptions not handled by asyncio
+  except Exception as e:
+    context = {'exception': e, 'message': str(e)}
+    loop.call_exception_handler(context)
+  # finalize the shutdown
+  finally:
+    loop.close()
+    logging.info('Successfully shutdown.')
 
 
 if __name__ == '__main__':

--- a/pairwise_macro_synteny_blocks/pairwise_macro_synteny_blocks/__main__.py
+++ b/pairwise_macro_synteny_blocks/pairwise_macro_synteny_blocks/__main__.py
@@ -5,6 +5,8 @@ import argparse
 import asyncio
 import logging
 import os
+import signal
+# dependencies
 import uvloop
 # module
 import pairwise_macro_synteny_blocks
@@ -104,18 +106,26 @@ def parseArgs():
   return parser.parse_args()
 
 
-# the main coroutine that starts the various program tasks
-async def main_coroutine(args):
-  redis_connection = await connectToRedis(args.rhost, args.rport, args.rdb, args.rpassword)
-  handler = RequestHandler(redis_connection)
-  tasks = []
-  if not args.nohttp:
-    http_task = asyncio.create_task(run_http_server(args.hhost, args.hport, handler))
-    tasks.append(http_task)
-  if not args.nogrpc:
-    grpc_task = asyncio.create_task(run_grpc_server(args.ghost, args.gport, handler))
-    tasks.append(grpc_task)
-  await asyncio.gather(*tasks)
+# graceful shutdown
+async def shutdown(loop, signal=None):
+  # report what signal (if any) initiated the shutdown
+  if signal:
+    logging.info(f'Received exit signal {signal.name}')
+  # cancel all running tasks (they know how to cleanup themselves)
+  logging.info('Cancelling outstanding tasks')
+  tasks = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+  [task.cancel() for task in tasks]
+  await asyncio.gather(*tasks, return_exceptions=True)
+  # stop the asyncio loop
+  loop.stop()
+
+
+# the asyncio exception handler that will initiate a shutdown
+def handleException(loop, context):
+  msg = context.get('exception', context['message'])
+  logging.critical(f'Caught exception: {msg}')
+  logging.info('Shutting down')
+  asyncio.create_task(shutdown(loop))
 
 
 def main():
@@ -127,6 +137,8 @@ def main():
 
   # setup logging
   log_config = {
+      'format': '%(asctime)s,%(msecs)d %(levelname)s: %(message)s',
+      'datefmt': '%H:%M:%S',
       'level': LOG_LEVELS[args.log_level],
     }
   if 'log_file' in args:
@@ -137,9 +149,36 @@ def main():
   loop = uvloop.new_event_loop()
   asyncio.set_event_loop(loop)
 
+  # setup asyncio exception handling
+  signals = (signal.SIGHUP, signal.SIGTERM, signal.SIGINT)
+  for s in signals:
+    loop.add_signal_handler(
+      s, lambda s=s: loop.create_task(shutdown(loop, signal=s))
+    )
+  loop.set_exception_handler(handleException)
+
   # run the program
-  loop.create_task(main_coroutine(args))
-  loop.run_forever()
+  try:
+    # create the database connection
+    redis_connection = loop.run_until_complete(connectToRedis(args.rhost, args.rport, args.rdb, args.rpassword))
+    # create the request handler
+    handler = RequestHandler(redis_connection)
+    # start the HTTP server
+    if not args.nohttp:
+      loop.create_task(run_http_server(args.hhost, args.hport, handler))
+    # start the gRPC server
+    if not args.nogrpc:
+      loop.create_task(run_grpc_server(args.ghost, args.gport, handler))
+    # run the main loop
+    loop.run_forever()
+  # catch exceptions not handled by asyncio
+  except Exception as e:
+    context = {'exception': e, 'message': str(e)}
+    loop.call_exception_handler(context)
+  # finalize the shutdown
+  finally:
+    loop.close()
+    logging.info('Successfully shutdown.')
 
 
 if __name__ == '__main__':

--- a/pairwise_macro_synteny_blocks/pairwise_macro_synteny_blocks/grpc_server.py
+++ b/pairwise_macro_synteny_blocks/pairwise_macro_synteny_blocks/grpc_server.py
@@ -12,7 +12,14 @@ class PairwiseMacroSyntenyBlocks(pairwisemacrosyntenyblocks_pb2_grpc.PairwiseMac
   def __init__(self, handler):
     self.handler = handler
 
-  async def Compute(self, request, context):
+  # create a context done callback that raises the given exception
+  def _exceptionCallbackFactory(self, exception):
+    def exceptionCallback(call):
+      raise exception
+    return exceptionCallback
+
+  # the method that actually handles requests
+  async def _compute(self, request, context):
     # required parameters
     chromosome = request.chromosome
     target = request.target
@@ -44,6 +51,22 @@ class PairwiseMacroSyntenyBlocks(pairwisemacrosyntenyblocks_pb2_grpc.PairwiseMac
       ), blocks))
     return pairwisemacrosyntenyblocks_pb2.PairwiseMacroSyntenyBlocksComputeReply(blocks=block_messages)
 
+  # implements the service's API
+  async def Compute(self, request, context):
+    # subvert the gRPC exception handler via a try/except block
+    try:
+      return await self._compute(request, context)
+    # let errors we raised go by
+    except aio.AbortError as e:
+      raise e
+    # raise an internal error to prevent non-gRPC info from being sent to users
+    except Exception as e:
+      # raise the exception after aborting so it gets logged
+      # NOTE: gRPC docs says abort should raise an error but it doesn't...
+      context.add_done_callback(self._exceptionCallbackFactory(e))
+      # return a gRPC INTERNAL error
+      await context.abort(grpc.StatusCode.INTERNAL, 'Internal server error')
+
 
 async def run_grpc_server(host, port, handler):
   server = aio.server()
@@ -53,3 +76,4 @@ async def run_grpc_server(host, port, handler):
     .add_PairwiseMacroSyntenyBlocksServicer_to_server(servicer, server)
   await server.start()
   await server.wait_for_termination()
+  # TODO: what about teardown? server.stop(None)

--- a/search/search/grpc_server.py
+++ b/search/search/grpc_server.py
@@ -1,4 +1,5 @@
 # dependencies
+import grpc
 from grpc.experimental import aio
 # module
 from search.proto.search_service.v1 import search_pb2
@@ -10,7 +11,8 @@ class Search(search_pb2_grpc.SearchServicer):
   def __init__(self, handler):
     self.handler = handler
 
-  async def Search(self, request, context):
+  # the method that actually handles requests
+  async def _search(self, request, context):
     results = await self.handler.process(request.query)
     reply = search_pb2.SearchReply()
     if 'genes' in results:
@@ -18,6 +20,22 @@ class Search(search_pb2_grpc.SearchServicer):
     if 'regions' in results:
         reply.regions.extend(results['regions'])
     return reply
+
+  # implements the service's API
+  async def Search(self, request, context):
+    # subvert the gRPC exception handler via a try/except block
+    try:
+      return await self._search(request, context)
+    # let errors we raised go by
+    except aio.AbortError as e:
+      raise e
+    # raise an internal error to prevent non-gRPC info from being sent to users
+    except Exception as e:
+      # raise the exception after aborting so it gets logged
+      # NOTE: gRPC docs says abort should raise an error but it doesn't...
+      context.add_done_callback(self._exceptionCallbackFactory(e))
+      # return a gRPC INTERNAL error
+      await context.abort(grpc.StatusCode.INTERNAL, 'Internal server error')
 
 
 async def run_grpc_server(host, port, query_parser):
@@ -27,3 +45,4 @@ async def run_grpc_server(host, port, query_parser):
   search_pb2_grpc.add_SearchServicer_to_server(servicer, server)
   await server.start()
   await server.wait_for_termination()
+  # TODO: what about teardown? server.stop(None)


### PR DESCRIPTION
This PR implements robust exception handling and graceful shutdowns in every service. Now each service's HTTP and gRPC servers keep running if error is recoverable, otherwise the service shuts down. In both scenarios, all errors are reported in the service's log, assuming the log level is set appropriately. Other, non-server related errors will also be logged and trigger a shutdown. The shutdown code does not explicitly tear down the serves or database connection, but rather, kills their asyncio tasks. This causes them to clean themselves up, i.e. the shutdown is implicitly graceful.