### PR TITLE
Redis loader updates

### DIFF
--- a/redis_loader/README.md
+++ b/redis_loader/README.md
@@ -35,6 +35,12 @@ The loading script can be run as follows
 
     $ python -m redis_loader
 
+By default, the loading script will only load new databases, i.e. no data will be loaded if the indexes it creates already exist.
+This behavior can be changed using the `--load-type` flag.
+For example, the following command will create a new database or append data to an existing database:
+
+    $ python -m redis_loader --load-type append
+
 For more information about the script and additional commands and arguments, run
 
     $ python -m redis_loader --help
@@ -43,8 +49,11 @@ If the program was built as a docker container, it can be run as follows
 
     $ docker run redis_loader
 
-Any `*.sh` scripts in the container /docker-entrypoint-initdb.d directory will be processed if the `REDIS_DB` (default 0) at `REDIS_HOST` (default 'localhost') on port `REDIS_PORT` (default 6379) is empty:
+When the loading script is run without any arguments AND the target Redis database is empty, any `*.sh` scripts in the container's `/docker-entrypoint-initdb.d/` directory will be executed in alphabetical order.
+Custom `*sh` scripts can be put in the container's `/docker-entrypoint-initdb/` directory using [volumes](https://docs.docker.com/storage/volumes/):
 
-    $ docker run -e REDIS_HOST=my-redis-db-host -v $PWD/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d redis_loader
+    $ docker run -v /path/to/local/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d:rw redis_loader
 
-See [gcv-docker-compose](https://github.com/legumeinfo/gcv-docker-compose#redis_loader) instructions for running in the context of the system for which the service was conceived (example with actual data given there!).
+These scripts should use the Python command above to load data.
+
+See the [gcv-docker-compose instructions](https://github.com/legumeinfo/gcv-docker-compose#loading-data) for examples of using the loading script.

--- a/redis_loader/entrypoint.sh
+++ b/redis_loader/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-if python <<END
+if [ $# -eq 0 ] && python <<END
 import sys, redis
 r = redis.Redis(host='${REDIS_HOST:-localhost}',
                 port=${REDIS_PORT:-6379},

--- a/redis_loader/redis_loader/__init__.py
+++ b/redis_loader/redis_loader/__init__.py
@@ -5,7 +5,7 @@ def int_or_str(value):
         return value
 
 
-__version__ = "1.2.3"
+__version__ = "1.3.0"
 VERSION = tuple(map(int_or_str, __version__.split(".")))
 
 __schema_version__ = "1.1.0"

--- a/redis_loader/redis_loader/__main__.py
+++ b/redis_loader/redis_loader/__main__.py
@@ -185,7 +185,7 @@ def parseArgs():
         envvar=loadtype_envvar,
         type=str,
         choices=list(load_types.keys()),
-        default="append",
+        default="new",
         help=f"""
         How the data should be loaded into Redis:\n{loadtype_help} (can also be
         specified using the {loadtype_envvar} environment variable).


### PR DESCRIPTION
This PR changes the default value of the Redis loader's `--load-type` flag from `append` to `new` so that users don't accidentally append to an existing database. It also updates the loader's `entrypoint.sh` script to only run scripts in the Docker container's `/docker-entrypoint-initdb.d/` directory when the Redis database is empty AND there's no command-line arguments. This, for example, will prevent the example script from running in the gcv-docker-compose repo when users want to load their own data via the command-line to initialize the database. Lastly, this PR bumps the redis_loader version to 1.3.0 so I can tag a release when it's merged and get the changes into the gcv-docker-compose repo ASAP.