### PR TITLE
Openapi homogenize part 2

### DIFF
--- a/dscensor/Dockerfile
+++ b/dscensor/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.1-slim-buster
+FROM python:3.11-slim-buster
 
 # install gcc and other build requirements
 RUN apt-get update && \

--- a/dscensor/Dockerfile
+++ b/dscensor/Dockerfile
@@ -25,8 +25,5 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 RUN pip3 install --no-cache-dir .
 
 WORKDIR /
-COPY ../data/dscensor/autocontent ./autocontent
-
-# set the locale
 
 ENTRYPOINT ["python3", "-u", "-m", "dscensor"]

--- a/dscensor/README.md
+++ b/dscensor/README.md
@@ -13,13 +13,13 @@ The "./autocontent" directory will be read by the app when docker compose is run
 
 Run local development build from cwd.
 
-`sudo docker compose -f ./compose.dev.yaml up`
+`docker compose -f compose.yaml -f compose.dev.yaml up`
 
 Run production build from tagged image.
 
-`sudo docker compose -f ./compose.prod.yaml up`
+`docker compose -f compose.yaml -f compose.prod.yaml up`
 
-# Develop
+# Development
 
 Install pre-commit hooks before developing. The github will force you to subscribe on PR if you don't so please do!
 

--- a/dscensor/compose.dev.yaml
+++ b/dscensor/compose.dev.yaml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
     environment:
-      nodes: "/autocontent"
+      NODES: "/autocontent"
     ports:
       - "${PORT:-8080}:8080"
     volumes:

--- a/dscensor/compose.dev.yaml
+++ b/dscensor/compose.dev.yaml
@@ -2,7 +2,9 @@ services:
   dscensor:
     build:
       context: .
+    environment:
+      nodes: "/autocontent"
     ports:
       - "${PORT:-8080}:8080"
     volumes:
-      - ${DATA}:/data
+      - ${DATA:-./autocontent}:/autocontent

--- a/dscensor/compose.prod.yaml
+++ b/dscensor/compose.prod.yaml
@@ -1,8 +1,10 @@
 services:
   dscensor:
     image: ghcr.io/legumeinfo/microservices-dscensor:1.0.0
+    environment:
+      nodes: "/autocontent"
     ports:
       - "${PORT:-8080}:8080"
     volumes:
-      - ${DATA}:/data
+      - ${DATA:-./autocontent}:/autocontent
     restart: always

--- a/dscensor/compose.prod.yaml
+++ b/dscensor/compose.prod.yaml
@@ -2,7 +2,7 @@ services:
   dscensor:
     image: ghcr.io/legumeinfo/microservices-dscensor:1.0.0
     environment:
-      nodes: "/autocontent"
+      NODES: "/autocontent"
     ports:
       - "${PORT:-8080}:8080"
     volumes:

--- a/dscensor/compose.yaml
+++ b/dscensor/compose.yaml
@@ -1,0 +1,4 @@
+services:
+  dscensor:
+    environment:
+      HTTP_HOST: "0.0.0.0"

--- a/dscensor/dscensor/__main__.py
+++ b/dscensor/dscensor/__main__.py
@@ -144,12 +144,6 @@ def handleException(loop, context):
     asyncio.create_task(shutdown(loop))
 
 
-# the main coroutine that starts the various program tasks
-def main_coroutine(args):
-    handler = RequestHandler(args.nodes)
-    return run_http_server(args.hhost, args.hport, handler)
-
-
 def main():
     # parse the command line arguments / environment variables
     args = parseArgs()
@@ -178,7 +172,9 @@ def main():
 
     # run the program
     try:
-        aiohttp.web.run_app(main_coroutine(args))
+        handler = RequestHandler(args.nodes)
+        loop.create_task(run_http_server(args.hhost, args.hport, handler))
+        loop.run_forever()
     # catch exceptions not handled by asyncio
     except Exception as e:
         context = {"exception": e, "message": str(e)}

--- a/dscensor/dscensor/__main__.py
+++ b/dscensor/dscensor/__main__.py
@@ -100,7 +100,7 @@ def parseArgs():
         "--port",
         action=EnvArg,
         envvar=port_envvar,
-        type=str,
+        type=int,
         default="8080",
         help=f"""
         The HTTP server port (can also be specified using the {port_envvar} environment

--- a/dscensor/dscensor/__main__.py
+++ b/dscensor/dscensor/__main__.py
@@ -101,7 +101,7 @@ def parseArgs():
         action=EnvArg,
         envvar=port_envvar,
         type=str,
-        default="8880",
+        default="8080",
         help=f"""
         The HTTP server port (can also be specified using the {port_envvar} environment
         variable).

--- a/dscensor/dscensor/__main__.py
+++ b/dscensor/dscensor/__main__.py
@@ -113,7 +113,7 @@ def parseArgs():
         action=EnvArg,
         envvar=nodes_envvar,
         type=str,
-        default="/autocontent",
+        default="./autocontent",
         help=f"""
         TODO (can also be specified using the {nodes_envvar} environment variable).
         """,

--- a/dscensor/dscensor/__main__.py
+++ b/dscensor/dscensor/__main__.py
@@ -107,24 +107,13 @@ def parseArgs():
         variable).
         """,
     )
-    app_key_envvar = "APP_KEY"
-    parser.add_argument(
-        "--appkey",
-        action=EnvArg,
-        envvar=app_key_envvar,
-        type=str,
-        default="digraph",
-        help=f"""
-        TODO (can also be specified using the {app_key_envvar} environment variable).
-        """,
-    )
     nodes_envvar = "NODES"
     parser.add_argument(
         "--nodes",
         action=EnvArg,
         envvar=nodes_envvar,
         type=str,
-        default="/app/autocontent",
+        default="/autocontent",
         help=f"""
         TODO (can also be specified using the {nodes_envvar} environment variable).
         """,

--- a/dscensor/dscensor/__main__.py
+++ b/dscensor/dscensor/__main__.py
@@ -7,8 +7,6 @@ import logging
 import os
 import signal
 
-import aiohttp
-
 # dependencies
 import uvloop
 

--- a/dscensor/dscensor/__main__.py
+++ b/dscensor/dscensor/__main__.py
@@ -83,27 +83,27 @@ def parseArgs():
     )
 
     # Async HTTP args
-    hhost_envvar = "HTTP_HOST"
+    host_envvar = "HTTP_HOST"
     parser.add_argument(
-        "--hhost",
+        "--host",
         action=EnvArg,
-        envvar=hhost_envvar,
+        envvar=host_envvar,
         type=str,
         default="127.0.0.1",
         help=f"""
-        The HTTP server host (can also be specified using the {hhost_envvar} environment
+        The HTTP server host (can also be specified using the {host_envvar} environment
         variable).
         """,
     )
-    hport_envvar = "HTTP_PORT"
+    port_envvar = "HTTP_PORT"
     parser.add_argument(
-        "--hport",
+        "--port",
         action=EnvArg,
-        envvar=hport_envvar,
+        envvar=port_envvar,
         type=str,
         default="8880",
         help=f"""
-        The HTTP server port (can also be specified using the {hport_envvar} environment
+        The HTTP server port (can also be specified using the {port_envvar} environment
         variable).
         """,
     )
@@ -173,7 +173,7 @@ def main():
     # run the program
     try:
         handler = RequestHandler(args.nodes)
-        loop.create_task(run_http_server(args.hhost, args.hport, handler))
+        loop.create_task(run_http_server(args.host, args.port, handler))
         loop.run_forever()
     # catch exceptions not handled by asyncio
     except Exception as e:

--- a/dscensor/dscensor/directed_graph.py
+++ b/dscensor/dscensor/directed_graph.py
@@ -14,12 +14,13 @@ import networkx as nx
 class DirectedGraphController:
     """Imported by application to build and query directed graph"""
 
-    def __init__(self, logger, dscensor_nodes="./autocontent"):
-        self.all_objects = {}  # collection of all objects for lookup in edge building
-        self.dscensor_nodes = os.path.abspath(
-            dscensor_nodes
-        )  # directory to load object.json files from lis-autocontent populate-dscensor
-        self.digraph = nx.DiGraph()  # initialize digraph
+    def __init__(self, dscensor_nodes="./autocontent"):
+        # collection of all objects for lookup in edge building
+        self.all_objects = {}
+        # directory to load object.json files from lis-autocontent populate-dscensor
+        self.dscensor_nodes = os.path.abspath(dscensor_nodes)
+        # initialize digraph
+        self.digraph = nx.DiGraph()
         self.parse_dscensor_nodes()
         self.generate_digraph()
 

--- a/dscensor/dscensor/http_server.py
+++ b/dscensor/dscensor/http_server.py
@@ -3,11 +3,9 @@ from pathlib import Path
 # dependencies
 from aiohttp import web
 from rororo import (
-    BaseSettings,
     OperationTableDef,
     openapi_context,
     setup_openapi,
-    setup_settings,
 )
 
 

--- a/dscensor/dscensor/http_server.py
+++ b/dscensor/dscensor/http_server.py
@@ -1,8 +1,4 @@
-import os
 from pathlib import Path
-from typing import Union
-
-import environ
 
 # dependencies
 from aiohttp import web
@@ -14,14 +10,8 @@ from rororo import (
     setup_settings,
 )
 
-from dscensor.directed_graph import DirectedGraphController
 
 operations = OperationTableDef()
-
-
-@environ.config(prefix=None, frozen=True)
-class Settings(BaseSettings):
-    input_nodes: str = environ.var(name="DSCENSOR_INPUT_NODES", default="./autocontent")
 
 
 @operations.register("getGenus")
@@ -58,37 +48,21 @@ async def list_gene_models(request):
     return web.json_response(gene_model_list)
 
 
-def run_http_server(host, port, handler, settings: Union[Settings, None] = None):
+async def run_http_server(host, port, handler):
     # make the app
-    if settings is None:
-        settings = Settings.from_environ()
-    app = setup_settings(
-        web.Application(),
-        settings,
-        loggers=("aiohttp", "aiohttp_middlewares", "dscensor", "rororo"),
-        remove_root_handlers=True,
-    )
-    nodes = os.getenv("DSCENSOR_NODES")
-    if not nodes:
-        nodes = "./autocontent"
-    app["handler"] = handler
-    app["digraph"] = DirectedGraphController(nodes)
-    # finish setting up the app using OpenAPI
     parent = Path(__file__).parent.parent
     api_path = f"{parent}/openapi/dscensor/v1/dscensor.yaml"
-    return setup_openapi(
-        app,
+    app = setup_openapi(
+        web.Application(),
         api_path,
         operations,
         is_validate_response=False,
         cors_middleware_kwargs={"allow_all": True},
     )
+    app["handler"] = handler
     # run the app
-
-
-#    runner = web.AppRunner()
-#    await runner.setup()
-#    site = web.TCPSite(runner, host, port)
-#    await site.start()
-#    web.run_app(setup_openapi, port=port, host=host)
-# TODO: what about teardown? runner.cleanup()
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, host, port)
+    await site.start()
+    # TODO: what about teardown? runner.cleanup()

--- a/dscensor/openapi/dscensor/v1/dscensor.yaml
+++ b/dscensor/openapi/dscensor/v1/dscensor.yaml
@@ -3,7 +3,7 @@ info:
   title: "RESTful API for DSCensor Directed Graph"
   version: 1.0.0
 servers:
-  - url: /api
+  - url: /
 paths:
   /genera:
     get:


### PR DESCRIPTION
This PR further homogenizes the dscensor microservice to be like the existing microservices. Most notably:

* The HTTP server is run as a coroutine so it doesn't block the main event loop.
* All settings and configurations for the HTTP server are provided from `__main__.py`.
* All logging is configured in `__main__.py`.
* The dev and prod docker compose files were revised to utilize a third compose file that contains common configurations that were missing from both files.
* The server in the spec is now the / path, instead of /api, as all other services use the latter.