### PR TITLE
Updated build-on-push runner from ubuntu-latest to ubuntu-latest

### DIFF
--- a/.github/workflows/build-push-on-tag.yml
+++ b/.github/workflows/build-push-on-tag.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   build-and-push-image:
     name: 'Microservice Docker image build and push'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This means the running should never go out of date.